### PR TITLE
Use Nevan font for nav buttons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -34,6 +34,10 @@ nav a {
   font-family: 'Nevan', Arial, sans-serif;
 }
 
+nav button {
+  font-family: 'Nevan', Arial, sans-serif;
+}
+
 nav a:hover {
   text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- ensure any navigation buttons use the Nevan typeface

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c8423a10c83289da18315ea399f5a